### PR TITLE
Make messages for stability rolls only appear once on failure

### DIFF
--- a/CBTBehaviors/CBTBehaviors/Patches/PilotingPatches.cs
+++ b/CBTBehaviors/CBTBehaviors/Patches/PilotingPatches.cs
@@ -37,13 +37,19 @@ namespace CBTBehaviors {
                         
                         if (skillTotal < Mod.Config.PilotStabilityCheck) {
                             Mod.Log.Debug(string.Format(" Skill Check Failed! Flagging for Knockdown"));
+                            bool showMessage = !target.IsFlaggedForKnockdown;
 
                             target.FlagForKnockdown();
-                            target.Combat.MessageCenter.PublishMessage(new AddSequenceToStackMessage(new ShowActorInfoSequence(target, $"Stability Check: Failed!", FloatieMessage.MessageNature.Debuff, true)));
+                            if (Mod.Config.ShowAllStabilityRolls || showMessage)
+                            {
+                                target.Combat.MessageCenter.PublishMessage(new AddSequenceToStackMessage(new ShowActorInfoSequence(target, $"Stability Check: Failed!", FloatieMessage.MessageNature.Debuff, true)));
+                            }
                         } else {
                             Mod.Log.Debug(string.Format(" Skill Check Succeeded!"));
-
-                            target.Combat.MessageCenter.PublishMessage(new AddSequenceToStackMessage(new ShowActorInfoSequence(target, $"Stability Check: Passed!", FloatieMessage.MessageNature.Buff, true)));
+                            if (Mod.Config.ShowAllStabilityRolls)
+                            {
+                                target.Combat.MessageCenter.PublishMessage(new AddSequenceToStackMessage(new ShowActorInfoSequence(target, $"Stability Check: Passed!", FloatieMessage.MessageNature.Buff, true)));
+                            }
                         }
                     } else {
                         Mod.Log.Debug($"  target has no stability damage, is not unsteady, or is dead or prone - skipping");

--- a/CBTBehaviors/CBTBehaviors/Properties/AssemblyInfo.cs
+++ b/CBTBehaviors/CBTBehaviors/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]

--- a/CBTBehaviors/CBTBehaviors/Utils/ModConfig.cs
+++ b/CBTBehaviors/CBTBehaviors/Utils/ModConfig.cs
@@ -23,6 +23,7 @@ namespace CBTBehaviors {
 
         // Piloting
         public float PilotStabilityCheck = 0.30f;
+        public bool ShowAllStabilityRolls = false;
 
         // Movement
         public int ToHitSelfJumped = 2;

--- a/mod.json
+++ b/mod.json
@@ -1,7 +1,7 @@
 {
     "Name": "CBTBehaviors",
     "Enabled": true,
-    "Version": "0.1.0",
+    "Version": "0.1.1",
     "Description": "",
     "Author": "McFistyBuns / FrostRaptor",
     "Website": "https://github.com/BattletechModders/CBTBehaviors/",


### PR DESCRIPTION
messages will not show at all if the roll is successful. this can be turned off by setting ShowAllStabilityRolls to true in the settings.

This implements a fix issue #4 